### PR TITLE
AC-868 Address Edittext fields updated

### DIFF
--- a/openmrs-client/src/main/res/values/strings.xml
+++ b/openmrs-client/src/main/res/values/strings.xml
@@ -47,8 +47,8 @@
     <string name="reg_ques_dob">Patient\'s birth date*</string>
     <string name="label_or">OR</string>
     <string name="reg_ques_address">Address</string>
-    <string name="addr1_hint">Address Line 1*</string>
-    <string name="addr2_hint">Address Line 2</string>
+    <string name="addr1_hint">Address Line 1*</ string>
+    <string name="addr2_hint">Address Line 2</ string>
     <string name="addr_invalid_error">Address cannot contain invalid characters</string>
     <string name="atleastone">Fill at least one address field</string>
 


### PR DESCRIPTION
AC-868: Address Edittext hint should mention "Address Line" instead of "Address"

## Description of what I changed

In the Register Patient Activity, in the Edittext field of Address there should be a hint like "Address Line 1", "Address Line 2" instead of only "Address".

Before- Address 1, Address 2
Now- Address Line 1, Address Line 2
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
JIRA Issue: https://issues.openmrs.org/browse/AC-868

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**. 
<!--- No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one -->

- No new Tests required
<!--- No? -> write tests and add them to this commit `git add . && git commit --amend`-->

- [x] All new and existing **tests passed**.
<!--- No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works. -->

- [x] My pull request is **based on the latest changes** of the master branch.
<!--- No? Unsure? -> execute command `git pull --rebase upstream master` -->